### PR TITLE
35 make categories editable to rename them

### DIFF
--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { IconType } from '$lib/types/IconType';
 	export let stroke: string;
-	export let size = '32';
+	export let size: string = '32';
 	export let type: IconType;
 </script>
 
@@ -95,7 +95,7 @@
 	{:else if type === IconType.Drag}
 		<path
 			fill={stroke}
-			d="M5 11q-.425 0-.713-.288T4 10q0-.425.288-.713T5 9h14q.425 0 .713.288T20 10q0 .425-.288.713T19 11H5Zm0 4q-.425 0-.713-.288T4 14q0-.425.288-.713T5 13h14q.425 0 .713.288T20 14q0 .425-.288.713T19 15H5Z"
+			d="M2.5 11h19a.5.5 0 0 0 0-1h-19a.5.5 0 0 0 0 1zm19 3h-19a.5.5 0 0 0 0 1h19a.5.5 0 0 0 0-1z"
 		/>
 	{/if}
 </svg>

--- a/src/lib/pocketbase.ts
+++ b/src/lib/pocketbase.ts
@@ -40,6 +40,23 @@ export async function deleteCategoryQuery(id: string) {
 	await pb.collection('categories').delete(id);
 }
 
+export async function getItemsPerCategory(id: string) {
+	const items = await pb.collection('items').getFullList<Item>({
+		filter: `created >= "2022-01-01 00:00:00" && category = "${id}"`
+	});
+	return items.map((item) => {
+		return {
+			id: item.id,
+			name: item.name,
+			picked: item.picked,
+			quantity: item.quantity,
+			category: item.category ? item.category : null,
+			list: item.list,
+			user: item.user
+		} as Item;
+	});
+}
+
 export async function getCategoriesQuery() {
 	const categories = deepClone(await pb.collection('categories').getFullList<Category>());
 	return categories.map((category) => {

--- a/src/lib/pocketbase.ts
+++ b/src/lib/pocketbase.ts
@@ -27,6 +27,19 @@ export async function getItemsInListQuery(listId: string, picked: boolean = fals
 	});
 }
 
+export async function getCategoryQuery(id: string) {
+	const category = await pb.collection('categories').getOne<Category>(id);
+	return {
+		id: category.id,
+		name: category.name,
+		user: category.user
+	} as Category;
+}
+
+export async function deleteCategoryQuery(id: string) {
+	await pb.collection('categories').delete(id);
+}
+
 export async function getCategoriesQuery() {
 	const categories = deepClone(await pb.collection('categories').getFullList<Category>());
 	return categories.map((category) => {

--- a/src/routes/categories/+layout.svelte
+++ b/src/routes/categories/+layout.svelte
@@ -1,0 +1,3 @@
+<div class="max-w-xl mx-auto mt-4 md:mt-8 mb-8">
+	<slot />
+</div>

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -4,6 +4,9 @@
 	import Button from '$lib/components/Button.svelte';
 	import Title from '$lib/components/Title.svelte';
 	import type { PageData } from './$types';
+	import Icon from '$lib/components/Icon.svelte';
+	import { IconType } from '$lib/types/IconType';
+	import { colors } from '$lib/util';
 
 	export let data: PageData;
 	export let form;
@@ -29,20 +32,14 @@
 		{:else}
 			<div class="flex flex-col justify-center w-full gap-3">
 				{#each data.categories as category}
-					<div class="bg-neutral rounded-lg shadow-lg h-14 px-4 flex justify-between items-center">
+					<div class="bg-neutral rounded-lg shadow-lg h-16 px-4 flex justify-between items-center">
 						<div class="text-gray-800 font-bold text-xl">{category.name}</div>
-						{#if $isPlanModeActive}
-							<div class="flex w-20">
-								<!-- <a href="/categories/{category.id}/edit" class="btn btn-primary mr-2">Edit</a> -->
-								<Button
-									height="h-10"
-									text="Delete"
-									onClick={() => {
-										modalCategoryId = category.id;
-									}}
-								/>
-							</div>
-						{/if}
+						<div class="flex gap-8">
+							<a href={'/categories/' + category.id} class=" w-20">
+								<Button height="h-10" text="Edit" backgroundColor="secondary" textStyle="small" />
+							</a>
+							<Icon type={IconType.Drag} size="40" stroke={colors.primary} />
+						</div>
 					</div>
 				{/each}
 			</div>

--- a/src/routes/categories/[categoryId]/+page.server.ts
+++ b/src/routes/categories/[categoryId]/+page.server.ts
@@ -1,4 +1,4 @@
-import { deleteCategoryQuery, getCategoriesQuery, getCategoryQuery } from '$lib/pocketbase';
+import { deleteCategoryQuery, getCategoryQuery, getItemsPerCategory } from '$lib/pocketbase';
 import { redirect, type Actions } from '@sveltejs/kit';
 
 export const load = ({ locals, params }) => {
@@ -16,8 +16,19 @@ export const load = ({ locals, params }) => {
 		}
 	};
 
+	const getItems = async () => {
+		try {
+			const items = getItemsPerCategory(params.categoryId);
+			return items;
+		} catch (err) {
+			console.error(err);
+			throw err;
+		}
+	};
+
 	return {
-		category: getCategory()
+		category: getCategory(),
+		items: getItems()
 	};
 };
 

--- a/src/routes/categories/[categoryId]/+page.server.ts
+++ b/src/routes/categories/[categoryId]/+page.server.ts
@@ -1,0 +1,45 @@
+import { deleteCategoryQuery, getCategoriesQuery, getCategoryQuery } from '$lib/pocketbase';
+import { redirect, type Actions } from '@sveltejs/kit';
+
+export const load = ({ locals, params }) => {
+	if (!locals.pb.authStore.isValid) {
+		throw redirect(303, '/login');
+	}
+
+	const getCategory = async () => {
+		try {
+			const category = getCategoryQuery(params.categoryId);
+			return category;
+		} catch (err) {
+			console.error(err);
+			throw err;
+		}
+	};
+
+	return {
+		category: getCategory()
+	};
+};
+
+export const actions: Actions = {
+	updateCategory: async ({ request, locals, params }) => {
+		const values = await request.formData();
+		const name = values.get('name') as string;
+		const { categoryId } = params;
+		if (!categoryId) return;
+
+		try {
+			await locals.pb.collection('categories').update(categoryId, { name });
+		} catch (err) {
+			console.error(err);
+			throw err;
+		}
+		throw redirect(303, `/categories/${params.categoryId}`);
+	},
+	deleteCategory: async ({ params }) => {
+		const { categoryId } = params;
+		if (!categoryId) return;
+		deleteCategoryQuery(categoryId);
+		throw redirect(303, '/categories');
+	}
+};

--- a/src/routes/categories/[categoryId]/+page.svelte
+++ b/src/routes/categories/[categoryId]/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import Button from '$lib/components/Button.svelte';
+	import Title from '$lib/components/Title.svelte';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+	const { category } = data;
+</script>
+
+<div class="px-4">
+	<div class="flex justify-between w-full mb-4">
+		<Title title={'Edit Category ' + category.name} />
+
+		<a href={'/categories'} class="w-20">
+			<Button text="Back" backgroundColor="secondary" textStyle="small" />
+		</a>
+	</div>
+
+	<form action="?/updateCategory" method="POST">
+		<div class="flex flex-col gap-4">
+			<input
+				type="text"
+				name="name"
+				placeholder="Name"
+				value={category.name}
+				class="bg-neutral px-4 text-md text-gray-700 border-2 border-gray-700 font-semibold rounded h-12 shadow-sm"
+			/>
+
+			<Button text="Update category" />
+		</div>
+	</form>
+	<div class="my-2">
+		<form action="?/deleteCategory" method="POST" use:enhance>
+			<Button height="h-10" text="Delete" backgroundColor="secondary" />
+		</form>
+	</div>
+</div>

--- a/src/routes/categories/[categoryId]/+page.svelte
+++ b/src/routes/categories/[categoryId]/+page.svelte
@@ -6,6 +6,14 @@
 
 	export let data: PageData;
 	const { category } = data;
+	const { items } = data;
+
+	const totalItems = items.length;
+	const totalItemsPicked = items.filter((item) => item.picked).length;
+	const totalItemsPickedPercentage = Math.round((totalItemsPicked / totalItems) * 100);
+	const differentLists = items
+		.map((item) => item.list)
+		.filter((value, index, self) => self.indexOf(value) === index);
 </script>
 
 <div class="px-4">
@@ -15,6 +23,13 @@
 		<a href={'/categories'} class="w-20">
 			<Button text="Back" backgroundColor="secondary" textStyle="small" />
 		</a>
+	</div>
+
+	<div class="my-10 font-normal">
+		You have assigned a total of <strong>{totalItems}</strong> items to this category, of which
+		<strong>{totalItemsPicked}</strong> are picked. That's
+		<strong>{totalItemsPickedPercentage}%</strong>. Those items are in
+		<strong>{differentLists.length}</strong> different lists.
 	</div>
 
 	<form action="?/updateCategory" method="POST">


### PR DESCRIPTION
Make category edit page, with rename and delete options.
Removed the PlanningMode from the categories page because it was confusing not being able to do things without an extra button click. 
Also included some stats for fun, could remove of course. Let me know what you think.